### PR TITLE
prefer magit-status-quick

### DIFF
--- a/matcha-magit.el
+++ b/matcha-magit.el
@@ -42,19 +42,6 @@
   (let ((current-prefix-arg '(4))) ; C-u
     (call-interactively 'magit-status)))
 
-(defun matcha-magit-status-or-switch-buffer ()
-  "Switch to existing `magit-status' without updating or run `magit-status'.
-If `magit' is not yet loaded yet, just call `magit-status' directly."
-  (interactive)
-  (if (not (featurep 'magit))
-      (magit-status-internal default-directory)
-    (if-let (magit-buffer
-             (magit-mode-get-buffer
-              #'magit-status-mode nil nil
-              (magit-buffer-lock-value #'magit-status-mode nil)))
-        (switch-to-buffer magit-buffer)
-      (magit-status-internal default-directory))))
-
 (define-transient-command matcha-magit-log ()
   "Log"
   [["File"
@@ -87,7 +74,7 @@ If `magit' is not yet loaded yet, just call `magit-status' directly."
   "Magit"
   [["Repository"
     ("s" "Status" magit-status)
-    ("g" "Status (Cached)" matcha-magit-status-or-switch-buffer)
+    ("g" "Status (Cached)" magit-status-quick)
     ("c" "Clone" magit-clone)
     ("r" "Pick Repository" matcha-magit-status-pick-repository)
     ("L" "List Repositories" magit-list-repositories)


### PR DESCRIPTION
Hello James,

Hope all is going well. Was looking into fixing the `matcha-magit-status-or-switch-buffer` function as `magit-buffer-lock-value` seems to be deprecated. Looks like since then, magit started providing a function very similar to the original one you had. I guess, these changes simplify things.

Best