### PR TITLE
replace deprecated define-transient-command

### DIFF
--- a/matcha-alchemist.el
+++ b/matcha-alchemist.el
@@ -53,7 +53,7 @@ If `mix-command' is \"phoenix.server\", then the resulting `defun' will be:
 
 (matcha-define-alchemist-function "phoenix.server" "deps.get")
 
-(define-transient-command matcha-alchemist-iex
+(transient-define-prefix matcha-alchemist-iex ()
   "IEX"
   [["Run"
     ("I" "Run" alchemist-iex-run )
@@ -67,7 +67,7 @@ If `mix-command' is \"phoenix.server\", then the resulting `defun' will be:
     ("c" "Compile Buffer" alchemist-iex-compile-this-buffer)
     ("m" "Reload Module" alchemist-iex-reload-module)]])
 
-(define-transient-command matcha-alchemist-eval
+(transient-define-prefix matcha-alchemist-eval ()
   "Eval"
   [["Eval"
     ("l" "Line" alchemist-eval-current-line)
@@ -88,7 +88,7 @@ If `mix-command' is \"phoenix.server\", then the resulting `defun' will be:
    ["IEX"
     ("i" "IEX..." matcha-alchemist-iex)]])
 
-(define-transient-command matcha-alchemist-test
+(transient-define-prefix matcha-alchemist-test ()
   "IEX"
   [["Test"
     ("t" "Test" alchemist-mix-test)
@@ -102,7 +102,7 @@ If `mix-command' is \"phoenix.server\", then the resulting `defun' will be:
    ["Misc"
     ("r" "Rerun Test" alchemist-mix-rerun-last-test)]])
 
-(define-transient-command matcha-alchemist-mix
+(transient-define-prefix matcha-alchemist-mix ()
   "Mix"
   [["Mix"
     ("m" "Mix" alchemist-mix)
@@ -110,7 +110,7 @@ If `mix-command' is \"phoenix.server\", then the resulting `defun' will be:
     ("r" "Run" alchemist-mix-run)
     ("h" "Help" alchemist-mix-help)]])
 
-(define-transient-command matcha-alchemist-help
+(transient-define-prefix matcha-alchemist-help ()
   "Help"
   [["Help"
     ("?" "Help" alchemist-help)
@@ -121,7 +121,7 @@ If `mix-command' is \"phoenix.server\", then the resulting `defun' will be:
     ("m" "Mix Help" alchemist-mix-help)
     ("H" "History Help" alchemist-help-history)]])
 
-(define-transient-command matcha-alchemist-phoenix
+(transient-define-prefix matcha-alchemist-phoenix ()
   "Phoenix"
   [["Routes"
     ("R" "Routes" alchemist-phoenix-routes)
@@ -136,7 +136,7 @@ If `mix-command' is \"phoenix.server\", then the resulting `defun' will be:
     ("v" "Views" alchemist-phoenix-find-views)
     ("w" "Web" alchemist-phoenix-find-web)]])
 
-(define-transient-command matcha-alchemist-mode
+(transient-define-prefix matcha-alchemist-mode ()
   "Alchemist"
   [["Actions"
     ;; FIXME: Dynamically plug in the phoenix related `transients'.

--- a/matcha-android-mode.el
+++ b/matcha-android-mode.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'android-mode nil t)
 
-(define-transient-command matcha-android-mode
+(transient-define-prefix matcha-android-mode ()
   "Android"
   [["Start"
     ("a" "Start App" android-start-app)

--- a/matcha-cc-mode.el
+++ b/matcha-cc-mode.el
@@ -45,7 +45,7 @@
              (format "javac %s" source))
         (command-execute 'compile)))))
 
-(define-transient-command matcha-java-mode
+(transient-define-prefix matcha-java-mode ()
   "Java"
   [["Actions"
     ("u" "Eval" matcha-cc-mode-java-eval-nofocus)]])

--- a/matcha-dired.el
+++ b/matcha-dired.el
@@ -37,7 +37,7 @@ one specified by listing header."
   (let ((default-directory (dired-current-directory)))
     (call-interactively #'find-file)))
 
-(define-transient-command matcha-dired-mode
+(transient-define-prefix matcha-dired-mode ()
   "Dired"
   [["Actions"
     ("f" "Find File" matcha-dired-find-file)
@@ -55,7 +55,7 @@ one specified by listing header."
     ("Q" "Exit Wdired" wdired-finish-edit)
     ("R" "Query Replace" dired-do-query-replace-regexp)]])
 
-(define-transient-command matcha-dired-operate
+(transient-define-prefix matcha-dired-operate ()
   "Operate"
   [["Actions"
     ("d" "Delete" dired-do-delete)
@@ -91,7 +91,7 @@ one specified by listing header."
     ("h" "Hardlink" dired-do-hardlink)
     ("l" "Symlink" dired-do-symlink)]])
 
-(define-transient-command matcha-dired-mark
+(transient-define-prefix matcha-dired-mark ()
   "Mark"
   [["Mark"
     ("m" "Mark" dired-mark)
@@ -113,7 +113,7 @@ one specified by listing header."
     ("[" "Previous" dired-prev-marked-file)
     ("]" "Next" dired-next-marked-file)]])
 
-(define-transient-command matcha-dired-regexp
+(transient-define-prefix matcha-dired-regexp ()
   "Regexp"
   [["Mark"
     ("*" "Mark for Regexp" dired-mark-files-regexp)
@@ -129,7 +129,7 @@ one specified by listing header."
     ("h" "Hardlink" dired-do-hardlink-regexp)
     ("s" "Symlink" dired-do-symlink-regexp)]])
 
-(define-transient-command matcha-dired-immediate
+(transient-define-prefix matcha-dired-immediate ()
   "Immediate"
   [["Find"
     ("ff" "Find" find-file)

--- a/matcha-eglot.el
+++ b/matcha-eglot.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'eglot nil t)
 
-(define-transient-command matcha-eglot
+(transient-define-prefix matcha-eglot ()
   "Eglot"
   [["Find"
     ("d" "Declaration" eglot-find-declaration)
@@ -46,13 +46,13 @@
     ("C" "Reconnect" eglot-reconnect)
     ("E" "Display Events Buffer" eglot-events-buffer)]])
 
-(define-transient-command matcha-eglot-format
+(transient-define-prefix matcha-eglot-format ()
   "Eglot Format"
   [["Format"
     ("=" "Format Buffer" eglot-format-buffer)
     ("R" "Format Region" eglot-format)]])
 
-(define-transient-command matcha-eglot-refactor
+(transient-define-prefix matcha-eglot-refactor ()
   "Eglot Refactor"
   [["Refactor"
     ("r" "Rename" eglot-rename)

--- a/matcha-elisp.el
+++ b/matcha-elisp.el
@@ -120,7 +120,7 @@ Requires smartparens because all movement is done using `sp-forward-symbol'."
    :mode '(emacs-lisp-mode lisp-interaction-mode)
    :command 'emr-show-refactor-menu))
 
-(define-transient-command matcha-emacs-lisp-debug
+(transient-define-prefix matcha-emacs-lisp-debug ()
   "Debug"
   [["Debug"
     ("d" "Debug" matcha-elisp-toggle-edebug-defun)
@@ -130,7 +130,7 @@ Requires smartparens because all movement is done using `sp-forward-symbol'."
     ("w" "Watch" debug-watch)
     ("W" "Cancel Watch" cancel-debug-watch)]])
 
-(define-transient-command matcha-emacs-lisp-eval ()
+(transient-define-prefix matcha-emacs-lisp-eval ()
   "Eval"
   [["Eval"
     ("e" "Last" eval-last-sexp)
@@ -143,7 +143,7 @@ Requires smartparens because all movement is done using `sp-forward-symbol'."
    ["Misc"
     ("j" "Eval and Print" eval-print-last-sexp)]])
 
-(define-transient-command matcha-elisp-refs ()
+(transient-define-prefix matcha-elisp-refs ()
   "References"
   [["References"
     ("f" "Function" elisp-refs-function)
@@ -152,7 +152,7 @@ Requires smartparens because all movement is done using `sp-forward-symbol'."
     ("v" "Variable" elisp-refs-variable)
     ("s" "Symbol" elisp-refs-symbol)]])
 
-(define-transient-command matcha-emacs-lisp-compile ()
+(transient-define-prefix matcha-emacs-lisp-compile ()
   "Compile"
   [["Compile"
     ("c" "Compile" emacs-lisp-byte-compile)
@@ -160,7 +160,7 @@ Requires smartparens because all movement is done using `sp-forward-symbol'."
     ("r" "Byte Recompile Directory" byte-recompile-directory)
     ("x" "Disassemble" disassemble)]])
 
-(define-transient-command matcha-emacs-lisp-describe ()
+(transient-define-prefix matcha-emacs-lisp-describe ()
   "Describe"
   [["Describe"
     ("f" "Function" describe-function)
@@ -169,7 +169,7 @@ Requires smartparens because all movement is done using `sp-forward-symbol'."
     ("y" "Syntax" describe-syntax)
     ("c" "Categories" describe-categories)]])
 
-(define-transient-command matcha-emacs-lisp-mode ()
+(transient-define-prefix matcha-emacs-lisp-mode ()
   "Emacs Lisp"
   [["Actions"
     ("c" "Compile..." matcha-emacs-lisp-compile)

--- a/matcha-go-mode.el
+++ b/matcha-go-mode.el
@@ -30,14 +30,14 @@
 (require 'matcha-base)
 (require 'go-mode nil t)
 
-(define-transient-command matcha-go-mode-eval
+(transient-define-prefix matcha-go-mode-eval ()
   "Eval"
   [["Eval"
     ("b" "Play Buffer" go-play-buffer)
     ("r" "Play Region" go-play-region)
     ("d" "Download Play" go-download-play)]])
 
-(define-transient-command matcha-go-mode-goto
+(transient-define-prefix matcha-go-mode-goto ()
   "Goto"
   [["Goto"
     ("a" "Arguments" go-goto-arguments)
@@ -48,13 +48,13 @@
     ("r" "Return Values" go-goto-return-values)
     ("m" "Method Receivers" go-goto-method-receivers)]])
 
-(define-transient-command matcha-go-doc
+(transient-define-prefix matcha-go-doc ()
   "Godoc"
   [["Actions"
     ("d" godoc)
     ("p" godoc-at-point)]])
 
-(define-transient-command matcha-go-mode
+(transient-define-prefix matcha-go-mode ()
   "Go"
   [
    :description (lambda () (format "Go: %s" (matcha-projectile-root)))
@@ -76,7 +76,7 @@
     ("ps" "Set Project" go-set-project)
     ("pR" "Reset GoPath" go-reset-gopath)]])
 
-(define-transient-command matcha-go-mode-guru
+(transient-define-prefix matcha-go-mode-guru ()
   "Guru"
   [[("d" "Describe" go-guru-describe)
     ("f" "Free Vars" go-guru-freevars)
@@ -91,7 +91,7 @@
     (">" "Callees" go-guru-callees)
     ("x" "Expand Region" go-guru-expand-region)]])
 
-(define-transient-command matcha-go-mode-godoctor
+(transient-define-prefix matcha-go-mode-godoctor ()
   "Doctor"
   ;; FIXME: It might be interesting to use an `transient' argument to toggle dry run.
   [["Doctor"

--- a/matcha-hg-histedit.el
+++ b/matcha-hg-histedit.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'hg-histedit nil t)
 
-(define-transient-command matcha-hg-histedit ()
+(transient-define-prefix matcha-hg-histedit ()
   "Histedit"
   [["Histedit"
     ("e" "Histedit at Point" hg-histedit-edit-at-point

--- a/matcha-js2-refactor.el
+++ b/matcha-js2-refactor.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 ;; (require 'js2-refactor nil t)
 
-(define-transient-command matcha-js2-refactor
+(transient-define-prefix matcha-js2-refactor ()
   "JS2 Refactor"
   [
    :description (lambda () (format "Javascript Refactor: %s" (matcha-heading-current-file)))

--- a/matcha-json-mode.el
+++ b/matcha-json-mode.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'json-mode nil t)
 
-(define-transient-command matcha-json-mode
+(transient-define-prefix matcha-json-mode ()
   "JSON"
   [["Actions"
     ("u" "Beautify" json-mode-beautify)]])

--- a/matcha-kotlin-mode.el
+++ b/matcha-kotlin-mode.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'kotlin-mode nil t)
 
-(define-transient-command matcha-kotlin-mode-eval
+(transient-define-prefix matcha-kotlin-mode-eval ()
   "Eval"
   [["Send"
     ("e" "Line" kotlin-send-line)
@@ -38,7 +38,7 @@
     ("k" "Block" kotlin-send-block)
     ("b" "Buffer" kotlin-send-buffer)]])
 
-(define-transient-command matcha-kotlin-mode
+(transient-define-prefix matcha-kotlin-mode ()
   "Kotlin"
   [["Actions"
     ("z" "REPL" kotlin-repl)

--- a/matcha-log-edit.el
+++ b/matcha-log-edit.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'log-edit nil t)
 
-(define-transient-command matcha-log-edit
+(transient-define-prefix matcha-log-edit ()
   "Log Edit"
   [["Actions"
     ("c" "Done" log-edit-done)

--- a/matcha-macrostep.el
+++ b/matcha-macrostep.el
@@ -37,7 +37,7 @@
       (call-interactively #'matcha-macrostep)
     (macrostep-expand)))
 
-(define-transient-command matcha-macrostep
+(transient-define-prefix matcha-macrostep ()
   "Macrostep"
   [["Expand"
     ("e" "Expand" macrostep-expand)

--- a/matcha-magit.el
+++ b/matcha-magit.el
@@ -42,7 +42,7 @@
   (let ((current-prefix-arg '(4))) ; C-u
     (call-interactively 'magit-status)))
 
-(define-transient-command matcha-magit-log ()
+(transient-define-prefix matcha-magit-log ()
   "Log"
   [["File"
     ("f" "Current" magit-log-buffer-file)
@@ -60,7 +60,7 @@
     ("C" "Current" magit-reflog-current)
     ("H" "Head" magit-reflog-head)]])
 
-(define-transient-command matcha-ediff ()
+(transient-define-prefix matcha-ediff ()
   "Ediff"
   [["Actions"
     ("f" "Files" ediff-files)
@@ -70,7 +70,7 @@
     ("d" "Directories" ediff-directories)
     ("D" "Directories - (3 Way)" ediff-directories3)]])
 
-(define-transient-command matcha-magit ()
+(transient-define-prefix matcha-magit ()
   "Magit"
   [["Repository"
     ("s" "Status" magit-status)

--- a/matcha-me.el
+++ b/matcha-me.el
@@ -168,7 +168,8 @@
 (defmacro matcha-create-project-actions (&rest actions)
   "Create a function to run a project action.
 
-ACTIONS has to be a key in `matcha-project-pkg-list' that's not :mode or :fallback."
+ACTIONS has to be a key in `matcha-project-pkg-list'
+that's not :mode or :fallback."
   `(progn
      ,@(cl-loop
         for action in actions
@@ -323,7 +324,7 @@ https://emacs.stackexchange.com/questions/24459/revert-all-open-buffers-and-igno
     (forward-char column)
     result))
 
-(define-transient-command matcha-org-space
+(transient-define-prefix matcha-org-space ()
   "Org"
   [["Org"
     ("a" "Agenda" org-agenda)
@@ -346,7 +347,7 @@ https://emacs.stackexchange.com/questions/24459/revert-all-open-buffers-and-igno
 
 (matcha-create-deferred-fn dired-sidebar-toggle-sidebar)
 
-(define-transient-command matcha-me-space ()
+(transient-define-prefix matcha-me-space ()
   "Space"
   [["Find"
     ("f" "File" matcha-me-find-file-dwim)
@@ -396,14 +397,14 @@ https://emacs.stackexchange.com/questions/24459/revert-all-open-buffers-and-igno
   (let ((transient-show-popup -.2))
     (transient-setup 'matcha-me-space)))
 
-(define-transient-command matcha-me-profiler
+(transient-define-prefix matcha-me-profiler ()
   "Profiler"
   [["Profiler"
     ("s" "Start" profiler-start)
     ("r" "Report" profiler-report)
     ("x" "Stop" profiler-stop)]])
 
-(define-transient-command matcha-me-bookmark
+(transient-define-prefix matcha-me-bookmark ()
   "Bookmark"
   [["Bookmark"
     ("b" "Set" bookmark-set)
@@ -412,7 +413,7 @@ https://emacs.stackexchange.com/questions/24459/revert-all-open-buffers-and-igno
     ("l" "List" bookmark-bmenu-list)
     ("s" "Save" bookmark-save)]])
 
-(define-transient-command matcha-me-system ()
+(transient-define-prefix matcha-me-system ()
   "System"
   [["System"
     ("f" "Finder" j-explorer-finder)
@@ -427,7 +428,7 @@ https://emacs.stackexchange.com/questions/24459/revert-all-open-buffers-and-igno
     ("p" "Profiler..." matcha-me-profiler)
     ("L" "List Processes" list-processes)]])
 
-(define-transient-command matcha-me-search ()
+(transient-define-prefix matcha-me-search ()
   "Search"
   [["Buffer"
     ("s" "Swiper" matcha-me-swiper)
@@ -447,7 +448,7 @@ https://emacs.stackexchange.com/questions/24459/revert-all-open-buffers-and-igno
    ["Other"
     ("a" "Rgrep" rgrep)]])
 
-(define-transient-command matcha-me-window ()
+(transient-define-prefix matcha-me-window ()
   "Window"
   [["Narrow/Widen"
     ("n" "Narrow" narrow-to-region)
@@ -482,7 +483,7 @@ https://emacs.stackexchange.com/questions/24459/revert-all-open-buffers-and-igno
          ("|" split-window-right)
          ("\\" split-window-right)])
 
-(define-transient-command matcha-me-files ()
+(transient-define-prefix matcha-me-files ()
   "Files"
   [["Current File"
     ("y" "Copy Filename to Clipboard" matcha-copy-current-filename-to-clipboard)
@@ -492,7 +493,7 @@ https://emacs.stackexchange.com/questions/24459/revert-all-open-buffers-and-igno
     ("O" "Open All from SavedFile" matcha-open-files-from-saved-files-list)
     ("R" "Revert/Refresh All" matcha-revert-all-file-buffers)]])
 
-(define-transient-command matcha-me-flymake ()
+(transient-define-prefix matcha-me-flymake ()
   "Flymake"
   [["Diagnostics"
     ("l" "Go to log buffer" flymake-switch-to-log-buffer)

--- a/matcha-mocha.el
+++ b/matcha-mocha.el
@@ -28,7 +28,7 @@
 (require 'matcha-base)
 (require 'mocha nil t)
 
-(define-transient-command matcha-mocha
+(transient-define-prefix matcha-mocha ()
   "Mocha"
   [["Test"
     ("f" "File" mocha-test-file)

--- a/matcha-omnisharp.el
+++ b/matcha-omnisharp.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 ;; (require 'omnisharp)
 
-(define-transient-command matcha-omnisharp-project
+(transient-define-prefix matcha-omnisharp-project ()
   "Project"
   [["Project"
     ("a" "Add To Solution" omnisharp-add-to-solution-current-file)
@@ -39,14 +39,14 @@
     ("R" "Remove From Solution Dired" omnisharp-remove-from-project-dired-selected-files)
     ("l" "Add Reference" omnisharp-add-reference)]])
 
-(define-transient-command matcha-omnisharp-refactor
+(transient-define-prefix matcha-omnisharp-refactor ()
   "Refactor"
   [["Refactor"
     ("m" "Rename" omnisharp-rename)
     ("i" "Rename Interactively" omnisharp-rename-interactively)
     ("r" "Code Action Refactoring" omnisharp-run-code-action-refactoring)]])
 
-(define-transient-command matcha-omnisharp-navigation
+(transient-define-prefix matcha-omnisharp-navigation ()
   "Navigation"
   [["Navigation"
     ("g" "Go To Definition" omnisharp-go-to-definition)
@@ -61,14 +61,14 @@
     ("F" "Solution Then File Member" omnisharp-navigate-to-solution-file-then-file-member)
     ("c" "Current File Member" omnisharp-navigate-to-current-file-member)]])
 
-(define-transient-command matcha-omnisharp-test
+(transient-define-prefix matcha-omnisharp-test ()
   "Test"
   [["Test"
     ("a" "All" omnisharp-unit-test-all)
     ("b" "Fixture" omnisharp-unit-test-fixture)
     ("t" "Single" omnisharp-unit-test-single)]])
 
-(define-transient-command matcha-omnisharp-help
+(transient-define-prefix matcha-omnisharp-help ()
   "Help"
   [["Help"
     ("t" "Current Type Information" omnisharp-current-type-information)
@@ -77,7 +77,7 @@
     ("r" "Reload Solution" omnisharp-reload-solution)
     ("S" "Stop Server" omnisharp-stop-server)]])
 
-(define-transient-command matcha-omnisharp-mode
+(transient-define-prefix matcha-omnisharp-mode ()
   "CSharp"
   [["Actions"
     ("m" "Build" omnisharp-build-in-emacs)

--- a/matcha-org.el
+++ b/matcha-org.el
@@ -30,13 +30,13 @@
 (require 'matcha-base)
 (require 'org)
 
-(define-transient-command matcha-org-babel ()
+(transient-define-prefix matcha-org-babel ()
   "Babel"
   ["Babel"
    ("e" "Execute Source Block" org-babel-execute-src-block )
    ("'" "Edit Source" org-edit-src-code )])
 
-(define-transient-command matcha-org-hyperlink ()
+(transient-define-prefix matcha-org-hyperlink ()
   "Org Links"
   [["Navigate"
     ("g" "Follow Link" org-open-at-point)
@@ -50,7 +50,7 @@
   [:hide (lambda () t)
          ("s" org-store-link)])
 
-(define-transient-command matcha-org-time ()
+(transient-define-prefix matcha-org-time ()
   "Time"
   [["Insert"
     ("t" "Timestamp" org-time-stamp)
@@ -70,7 +70,7 @@
     ("y" "Evaluate Time Range" org-evaluate-time-range)
     ("Z" "Custom Time Format" org-toggle-time-stamp-overlays)]])
 
-(define-transient-command matcha-org-change-date ()
+(transient-define-prefix matcha-org-change-date ()
   "Change Date"
   ["Change Date"
    ("l" "1 Day Later" org-shiftright)
@@ -78,7 +78,7 @@
    ("k" "1 ... Later" org-shiftup)
    ("j" "1 ... Before" org-shiftdown)])
 
-(define-transient-command matcha-org-editing ()
+(transient-define-prefix matcha-org-editing ()
   "Edit"
   [
    :description
@@ -115,7 +115,7 @@
     ("nb" "Narrow to Block" org-narrow-to-block)
     ("nw" "Widen" widen)]])
 
-(define-transient-command matcha-org-mode ()
+(transient-define-prefix matcha-org-mode ()
   "Org Mode"
   [
    :description

--- a/matcha-pass.el
+++ b/matcha-pass.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'password-store nil t)
 
-(define-transient-command matcha-pass-mode
+(transient-define-prefix matcha-pass-mode ()
   "Pass"
   [["Get"
     ("e" "Edit" password-store-edit)

--- a/matcha-project.el
+++ b/matcha-project.el
@@ -65,7 +65,7 @@ With a prefix argument, show NLINES of context."
                  (car (occur-read-primary-args))
                  nlines)))
 
-(define-transient-command matcha-project ()
+(transient-define-prefix matcha-project ()
   "Project"
   [["Find"
     ("f" "File" project-find-file)

--- a/matcha-projectile.el
+++ b/matcha-projectile.el
@@ -38,7 +38,7 @@
         (file-name-directory (projectile-project-root))))
     "Not in Project"))
 
-(define-transient-command matcha-projectile-cache ()
+(transient-define-prefix matcha-projectile-cache ()
   "Cache"
   [["Cache"
     ("c" "Invalidate" projectile-invalidate-cache)
@@ -46,7 +46,7 @@
     ("k" "Cache Current File" projectile-cache-current-file)
     ("s" "Cleanup Known Projects" projectile-cleanup-known-projects)]])
 
-(define-transient-command matcha-projectile ()
+(transient-define-prefix matcha-projectile ()
   "Projectile"
   [["Find"
     ("f" "File" projectile-find-file)

--- a/matcha-python.el
+++ b/matcha-python.el
@@ -33,7 +33,7 @@
 (declare-function 'lispy-eval "lispy")
 (declare-function 'lispy-eval-and-insert "lispy")
 
-(define-transient-command matcha-python-skeleton
+(transient-define-prefix matcha-python-skeleton ()
   "Skeleton"
   [["Template"
     ("i" "If" python-skeleton-if)
@@ -44,7 +44,7 @@
     ("d" "Def" python-skeleton-def)
     ("I" "Import" python-skeleton-import)]])
 
-(define-transient-command matcha-python-eval
+(transient-define-prefix matcha-python-eval ()
   "Eval"
   [["Send"
     ("r" "Region" python-shell-send-region)
@@ -58,7 +58,7 @@
     ("e" lispy-eval)
     ("i" lispy-eval-and-insert)]])
 
-(define-transient-command matcha-python-mode
+(transient-define-prefix matcha-python-mode ()
   "Python"
   [["Actions"
     ("z" "Switch to Shell" python-shell-switch-to-shell)

--- a/matcha-restclient.el
+++ b/matcha-restclient.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'restclient nil t)
 
-(define-transient-command matcha-restclient-mode
+(transient-define-prefix matcha-restclient-mode ()
   "Restclient"
   [["Query (Under Cursor)"
     ("e" "Run Query" restclient-http-send-current)

--- a/matcha-rust-mode.el
+++ b/matcha-rust-mode.el
@@ -31,14 +31,14 @@
 (require 'rust-mode nil t)
 (require 'cargo nil t)
 
-(define-transient-command matcha-rust-mode-cargo-test
+(transient-define-prefix matcha-rust-mode-cargo-test ()
   "Cargo Test"
   [["Test"
     ("t" "Test" cargo-process-test)
     ("c" "Current Test" cargo-process-current-test)
     ("f" "Current File" cargo-process-current-file-tests)]])
 
-(define-transient-command matcha-rust-mode-cargo
+(transient-define-prefix matcha-rust-mode-cargo ()
   "Cargo"
   [
    :description (lambda () (format "Cargo: %s" (matcha-projectile-root)))
@@ -66,7 +66,7 @@
     ("s" "Cargo Search" cargo-process-search)
     ("P" "Promote Module into Directory" rust-promote-module-into-dir)]])
 
-(define-transient-command matcha-rust-mode-eval
+(transient-define-prefix matcha-rust-mode-eval ()
   "Eval"
   [["Eval"
     ("r" "Region" rust-playpen-region)

--- a/matcha-slime.el
+++ b/matcha-slime.el
@@ -34,7 +34,7 @@
 
 ;; TODO: Add Debug Transient
 
-(define-transient-command matcha-slime-mode-eval
+(transient-define-prefix matcha-slime-mode-eval ()
   "Eval"
   [["Eval"
     ("e" "Expression" slime-eval-last-expression)
@@ -61,14 +61,14 @@
     ("n" "Remove Notes" slime-remove-notes)
     ("i" "Interrupt" slime-interrupt)]])
 
-(define-transient-command matcha-slime-mode-connection
+(transient-define-prefix matcha-slime-mode-connection ()
   "Connections"
   [["Connections"
     ("n" "Next Connection" slime-next-connection)
     ("p" "Previous Connection" slime-prev-connection)
     ("l" "List Connections" slime-list-connections)]])
 
-(define-transient-command matcha-slime-mode-info
+(transient-define-prefix matcha-slime-mode-info ()
   "Info"
   [["Apropos"
     ("a" "Apropos" slime-apropos)
@@ -79,7 +79,7 @@
     ("d" "Disassemble Symbol" slime-disassemble-symbol)
     ("H" "Hyperspec Lookup" slime-hyperspec-lookup)]])
 
-(define-transient-command matcha-slime-mode-references
+(transient-define-prefix matcha-slime-mode-references ()
   "References"
   [["Who"
     ("r" "References" slime-who-references)
@@ -93,7 +93,7 @@
     ("C" "Callers" slime-list-callers)
     ("E" "Callees" slime-list-callees)]])
 
-(define-transient-command matcha-slime-mode
+(transient-define-prefix matcha-slime-mode ()
   "SLIME"
   [["Actions"
     ("e" "Eval..." matcha-slime-mode-eval)

--- a/matcha-smerge-mode.el
+++ b/matcha-smerge-mode.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'smerge-mode)
 
-(define-transient-command matcha-smerge-mode
+(transient-define-prefix matcha-smerge-mode ()
   "Smerge"
   [
    :description (lambda () (format "Smerge: %s" (matcha-projectile-root)))

--- a/matcha-swift-mode.el
+++ b/matcha-swift-mode.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'swift-mode nil t)
 
-(define-transient-command matcha-swift-mode
+(transient-define-prefix matcha-swift-mode ()
   "Swift"
   [["Actions"
     ("z" "Run REPL" swift-mode:run-repl)

--- a/matcha-term.el
+++ b/matcha-term.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'term nil t)
 
-(define-transient-command matcha-term
+(transient-define-prefix matcha-term ()
   "Term"
   [["Actions"
     ("c" "Switch to Character Mode" term-char-mode)

--- a/matcha-tide.el
+++ b/matcha-tide.el
@@ -33,14 +33,14 @@
 (require 'tide nil t)
 ;; (require 'ts-comint)
 
-(define-transient-command matcha-tide-refactor
+(transient-define-prefix matcha-tide-refactor ()
   "Refactor"
   [["Actions"
     ("n" "Rename" tide-rename-symbol)
     ("r" "Refactor" tide-refactor)
     ("f" "Fix" tide-fix)]])
 
-(define-transient-command matcha-tide-eval
+(transient-define-prefix matcha-tide-eval ()
   "Eval"
   [["Send"
     ("e" "Sexp" ts-send-last-sexp)
@@ -50,7 +50,7 @@
    ["Misc"
     ("l" "Load File and Go" ts-load-file-and-go)]])
 
-(define-transient-command matcha-tide-mode
+(transient-define-prefix matcha-tide-mode ()
   "Typescript"
   [["Actions"
     ("e" "Eval..." matcha-tide-eval)

--- a/matcha-vc-dir.el
+++ b/matcha-vc-dir.el
@@ -30,7 +30,7 @@
 (require 'matcha-base)
 (require 'vc-dir nil t)
 
-(define-transient-command matcha-vc-dir-log
+(transient-define-prefix matcha-vc-dir-log ()
   "Log"
   [["Log"
     ("l" "Log" vc-print-log)
@@ -38,14 +38,14 @@
     ("i" "Log Incoming" vc-log-incoming)
     ("o" "Log Outgoing" vc-log-outgoing)]])
 
-(define-transient-command matcha-vc-dir-branch
+(transient-define-prefix matcha-vc-dir-branch ()
   "Branch"
   [["Branch"
     ("c" "Create" vc-create-tag)
     ("l" "Print Log" vc-print-branch-log)
     ("s" "Retrieve" vc-retrieve-tag)]])
 
-(define-transient-command matcha-vc-dir
+(transient-define-prefix matcha-vc-dir ()
   "VC"
   [["Actions"
     ("c" "Next Action" vc-next-action)

--- a/matcha-vc-hgcmd.el
+++ b/matcha-vc-hgcmd.el
@@ -71,7 +71,7 @@
     (message (format "Running: hg %s..." command))
     (vc-hgcmd-runcommand command)))
 
-(define-transient-command matcha-vc-hgcmd-stash ()
+(transient-define-prefix matcha-vc-hgcmd-stash ()
   "Stash uncommited changes."
   ["Arguments"
    ("-u" "Store unknown files in the shelve" ("-u" "--unknown"))


### PR DESCRIPTION
use `transient-define-prefix` instead of deprecated `define-transient-command`. (see: https://github.com/magit/transient/commit/2143a9585cad1da61774a34635b2f50ebaedb0e6).
add mandatory arglist where missing.
